### PR TITLE
ignoring non-numeric characters

### DIFF
--- a/format-as-currency.js
+++ b/format-as-currency.js
@@ -65,7 +65,9 @@ angular
       })
 
       ngModel.$parsers.push(function (value) {
-
+        // ignore non-numeric characters
+        value = value.replace(/[a-zA-Z!\?>:;\|<@#%\^&\*\)\(\+\/\\={}\[\]_]/g, '')
+        
         var number = util
           .toFloat(value)
           .toFixed(2)

--- a/test/format-as-currency.js
+++ b/test/format-as-currency.js
@@ -126,6 +126,25 @@ describe ('format-as-currency', function () {
 
     })
 
+    it ('should ignore special characters', function() {
+      [
+        ['$0.00', '0.00'],
+        ['$abcdWXYZ123,456', '123456.00'],
+        ['!@#$%^&*()_+$123,456', '123456.00'],
+        ['={}[]\\/><:;$123,456.00', '123456.00']
+      ]
+      .forEach(function (testCase) {
+
+        element
+          .val(testCase[0])
+          .triggerHandler('change')
+
+        expect(scope.value)
+          .toBe(testCase[1])
+
+      })
+    })
+
   })
 
   describe ('formatAsCurrencyUtilities', function () {


### PR DESCRIPTION
A user was able to type some non-numeric characters if the cursor was on either side of the currency symbol.  Now it behaves the same way regardless of where the cursor is.
