### PR TITLE
Locale fix

### DIFF
--- a/format-as-currency.js
+++ b/format-as-currency.js
@@ -65,6 +65,11 @@ angular
           // set the cursor back to its expected position
           // (since $render resets the cursor the the end)
           element[0].setSelectionRange(selectonRange[0], selectonRange[1])
+        } else {
+          ngModel.$setViewValue('')
+          ngModel.$render()
+
+          return void 0
         }
 
         return number


### PR DESCRIPTION
This PR makes the plugin work with locales other than the default.

When I loaded a locale javascript for pt_BR, for example, and tried to type anything on the input, it would fall on a infinite loop.

For that to work, I had to changed a few things.

**First I changed the regex on the formatAsCurrencyUtilities.toFloat**  
Instead of a fixed regex, it will be generated based on the current locale's currency symbol and group separator.
This way the "parse" will supposedly work with any locale.

**I also changed the way you detect the change in char count**
Yours wasn't working with other locales.
What I do instead is:
- Get the index of the _decimal separator_ (in current locale) of the formatted value
- Get the index of the _decimal separator_ (in current locale) of the _value that comes from the input_
- Subtract one from the other.

This way the code is much smaller, and have given me the same results as the old code. And works with locales other than `en`.

**And last, but not least**

You had a regex to ignore non-numeric chars, but it wasn't working with locales other than en.

I removed it, and instead, on the new else condition of 

``` javascript
if (ngModel.$validators.currency(number)) {
```

I cleaned up the value of the input. This way it would have a similar behavior to before, and no user would try to type an text there.

I haven't written tests, because I don't know how to in JavaScript. But mostly it's just removing the tests for the methods of the `formatAsCurrencyUtilities` I removed because they weren't being used anymore.
