### PR TITLE
Fix main entry in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "format-as-currency",
-  "main": "format-as-currency.js",
+  "main": "dist/format-as-currency.js",
   "version": "3.0.0",
   "authors": [
     "Boris Cherny <boris@performancejs.com>"


### PR DESCRIPTION
`main` entry was poiting to a non-existing file in project's root.
This prevented browserify+debowerify to load the module.

This commit fixes the `main` entry in `bower.json`, making it
match `package.json`'s one.
