### PR TITLE
Update bower.json for Angular 1.5.x

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -32,9 +32,9 @@
     "tests"
   ],
   "dependencies": {
-    "angular": "~1.4.7"
+    "angular": ">=1.3 <1.6"
   },
   "devDependencies": {
-    "angular-mocks": "~1.4.7"
+    "angular-mocks": ">=1.3 <1.6"
   }
 }


### PR DESCRIPTION
Updated bower.json to allow bower install without forcing when using Angular 1.5.x

Fixes #20 
